### PR TITLE
MAINT tqdm.auto to suppress warnings; package structure

### DIFF
--- a/hubness/analysis/__init__.py
+++ b/hubness/analysis/__init__.py
@@ -1,0 +1,4 @@
+from .estimation import Hubness
+
+__all__ = ['Hubness',
+           ]

--- a/hubness/neighbors/lsh.py
+++ b/hubness/neighbors/lsh.py
@@ -10,7 +10,7 @@ from sklearn.metrics import euclidean_distances
 from sklearn.metrics.pairwise import cosine_distances
 from sklearn.utils.validation import check_is_fitted, check_array
 import falconn
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 from .approximate_neighbors import ApproximateNearestNeighbor
 __all__ = ['LSH']

--- a/hubness/neighbors/lsh.py
+++ b/hubness/neighbors/lsh.py
@@ -95,12 +95,12 @@ class LSH(ApproximateNearestNeighbor):
             neigh_dist = np.empty_like(neigh_ind, dtype=X.dtype)
 
         # If verbose, show progress bar on the search loop
-        if not self.verbose:
-            enumerate_X = enumerate(X)
-        else:
+        if self.verbose:
             enumerate_X = tqdm(enumerate(X),
                                desc='LSH',
                                total=X.shape[0], )
+        else:
+            enumerate_X = enumerate(X)
         for i, x in enumerate_X:
             knn = np.array(query.find_k_nearest_neighbors(x, k=n_retrieve))
             if query_is_train:
@@ -168,12 +168,12 @@ class LSH(ApproximateNearestNeighbor):
             neigh_dist = np.empty_like(neigh_ind)
 
         # If verbose, show progress bar on the search loop
-        if not self.verbose:
-            enumerate_X = enumerate(X)
-        else:
+        if self.verbose:
             enumerate_X = tqdm(enumerate(X),
                                desc='LSH',
                                total=X.shape[0], )
+        else:
+            enumerate_X = enumerate(X)
         for i, x in enumerate_X:
             knn = np.array(query.find_near_neighbors(x, threshold=radius))
             if len(knn) == 0:

--- a/hubness/reduction/mutual_proximity.py
+++ b/hubness/reduction/mutual_proximity.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 from scipy import stats
 from sklearn.utils.validation import check_is_fitted, check_consistent_length, check_array
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 
 class MutualProximity:

--- a/hubness/reduction/scaling.py
+++ b/hubness/reduction/scaling.py
@@ -55,11 +55,11 @@ class LocalScaling:
 
         # Optionally show progress of local scaling loop
         if self.verbose:
-            range_n_test = range(n_test)
-        else:
             range_n_test = tqdm(range(n_test),
                                 total=n_test,
                                 desc=f'LS {self.method}')
+        else:
+            range_n_test = range(n_test)
 
         # Perform standard local scaling...
         if self.method.upper() in ['LS', 'STANDARD']:

--- a/hubness/reduction/scaling.py
+++ b/hubness/reduction/scaling.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 from sklearn.utils.validation import check_is_fitted, check_consistent_length
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 
 class LocalScaling:


### PR DESCRIPTION
Using `tqdm.auto` instead of `tqdm.autonotebook` suppresses the ExperimentalWarning.
Added `Hubness` to the `analysis` package. 